### PR TITLE
Update .pre-commit-config.yaml pylint repo

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -103,7 +103,7 @@ repos:
         plugins/.*
       )$
 - repo: https://github.com/PyCQA/pylint
-  rev: v3.0.0a3
+  rev: pylint-3.0.0a3
   hooks:
   - id: pylint
     additional_dependencies:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -102,7 +102,7 @@ repos:
         test/local-content/.*|
         plugins/.*
       )$
-- repo: https://github.com/pre-commit/mirrors-pylint
+- repo: https://github.com/PyCQA/pylint
   rev: v3.0.0a3
   hooks:
   - id: pylint


### PR DESCRIPTION
According to https://github.com/pre-commit/mirrors-pylint readme `This mirror repository is deprecated, use pylint directly.`

The result is the mirrors-pylint repo is missing a bunch of tags that pylint has.